### PR TITLE
Add observables via select()

### DIFF
--- a/config.js
+++ b/config.js
@@ -34,6 +34,7 @@ System.config({
     "redux": "npm:redux@3.4.0",
     "redux-thunk": "npm:redux-thunk@2.0.1",
     "reflect-metadata": "npm:reflect-metadata@0.1.3",
+    "rxjs": "npm:rxjs@5.0.0-beta.6",
     "typescript": "npm:typescript@1.8.9",
     "zone.js": "npm:zone.js@0.6.10",
     "github:jspm/nodelibs-assert@0.1.0": {
@@ -312,6 +313,10 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:rxjs@5.0.0-beta.5": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:rxjs@5.0.0-beta.6": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },

--- a/config.js
+++ b/config.js
@@ -31,7 +31,7 @@ System.config({
     "bootstrap": "github:twbs/bootstrap@3.3.6",
     "crypto": "github:jspm/nodelibs-crypto@0.1.0",
     "css": "github:systemjs/plugin-css@0.1.20",
-    "redux": "npm:redux@3.4.0",
+    "redux": "npm:redux@3.5.1",
     "redux-thunk": "npm:redux-thunk@2.0.1",
     "reflect-metadata": "npm:reflect-metadata@0.1.3",
     "rxjs": "npm:rxjs@5.0.0-beta.6",
@@ -229,7 +229,7 @@ System.config({
     "npm:inherits@2.0.1": {
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
-    "npm:lodash@4.9.0": {
+    "npm:lodash@4.11.1": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
@@ -284,7 +284,7 @@ System.config({
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:readable-stream@1.1.13": {
+    "npm:readable-stream@1.1.14": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "core-util-is": "npm:core-util-is@1.0.2",
       "events": "github:jspm/nodelibs-events@0.1.1",
@@ -294,11 +294,12 @@ System.config({
       "stream-browserify": "npm:stream-browserify@1.0.0",
       "string_decoder": "npm:string_decoder@0.10.31"
     },
-    "npm:redux@3.4.0": {
-      "lodash": "npm:lodash@4.9.0",
-      "lodash-es": "npm:lodash-es@4.9.0",
+    "npm:redux@3.5.1": {
+      "lodash": "npm:lodash@4.11.1",
+      "lodash-es": "npm:lodash-es@4.11.1",
       "loose-envify": "npm:loose-envify@1.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.2"
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "symbol-observable": "npm:symbol-observable@0.2.2"
     },
     "npm:reflect-metadata@0.1.2": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",
@@ -329,7 +330,7 @@ System.config({
     "npm:stream-browserify@1.0.0": {
       "events": "github:jspm/nodelibs-events@0.1.1",
       "inherits": "npm:inherits@2.0.1",
-      "readable-stream": "npm:readable-stream@1.1.13"
+      "readable-stream": "npm:readable-stream@1.1.14"
     },
     "npm:string_decoder@0.10.31": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
       "redux": "npm:redux@^3.1.7",
       "redux-thunk": "npm:redux-thunk@^2.0.1",
       "reflect-metadata": "npm:reflect-metadata@^0.1.3",
+      "rxjs": "npm:rxjs@^5.0.0-beta.6",
       "zone.js": "npm:zone.js@^0.6.10"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/InfomediaLtd/angular2-redux#readme",
   "peerDependencies": {
-    "redux": "^3.1.7",
+    "redux": "^3.5.1",
     "redux-thunk": "^2.0.1"
   },
   "dependencies": {},
@@ -57,7 +57,7 @@
     "karma-phantomjs-launcher": "^0.2.3",
     "phantomjs": "^1.9.19",
     "phantomjs-polyfill": "0.0.1",
-    "redux": "^3.1.7",
+    "redux": "^3.5.1",
     "redux-thunk": "^2.0.1",
     "reflect-metadata": "0.1.2",
     "rimraf": "^2.4.4",
@@ -83,7 +83,7 @@
     "dependencies": {
       "angular2": "npm:angular2@^2.0.0-beta.14",
       "crypto": "github:jspm/nodelibs-crypto@^0.1.0",
-      "redux": "npm:redux@^3.1.7",
+      "redux": "npm:redux@3.5.1",
       "redux-thunk": "npm:redux-thunk@^2.0.1",
       "reflect-metadata": "npm:reflect-metadata@^0.1.3",
       "rxjs": "npm:rxjs@^5.0.0-beta.6",

--- a/src/app-store.ts
+++ b/src/app-store.ts
@@ -1,3 +1,9 @@
+import {Observable} from "rxjs/Observable";
+
+// ensure required operators are enabled
+import "rxjs/add/operator/map";
+import "rxjs/add/operator/distinctUntilChanged";
+
 /**
  * Wrapper for app store
  */
@@ -20,6 +26,8 @@ export class AppStore {
      */
     public createDispatcher:(actionCreator, context)=>(...n:any[])=>void;
 
+    private _value:Observable<any>;
+
     constructor(store:any) {
         this.getState = () => {
             return store.getState();
@@ -34,7 +42,21 @@ export class AppStore {
         this.createDispatcher = (actionCreator, context):(...n:any[])=>void => {
             return (...args) => store.dispatch(actionCreator.call(context, ...args));
         };
+        this._value = Observable.create(observer => {
+            observer.next(this.getState());
+            this.subscribe(state => observer.next(state));
+        });
     }
 
-
+    select<R>(keyOrSelector: ((state: any) => R) | string | number | symbol): Observable<R> {
+        if (typeof keyOrSelector === "string" || typeof keyOrSelector === "number"
+                || typeof keyOrSelector === "symbol") {
+            return this._value.map(state => state[<string|number|symbol>keyOrSelector]).distinctUntilChanged();
+        } else if (typeof keyOrSelector === "function") {
+            return this._value.map(keyOrSelector).distinctUntilChanged();
+        } else {
+            throw new TypeError(`Unknown Parameter Type: `
+                + `Expected type of function or valid key type, got ${typeof keyOrSelector}`);
+        }
+    }
 }

--- a/src/app-store.ts
+++ b/src/app-store.ts
@@ -3,6 +3,7 @@ import {Observable} from "rxjs/Observable";
 // ensure required operators are enabled
 import "rxjs/add/operator/map";
 import "rxjs/add/operator/distinctUntilChanged";
+import "rxjs/add/observable/from";
 
 /**
  * Wrapper for app store
@@ -42,10 +43,7 @@ export class AppStore {
         this.createDispatcher = (actionCreator, context):(...n:any[])=>void => {
             return (...args) => store.dispatch(actionCreator.call(context, ...args));
         };
-        this._value = Observable.create(observer => {
-            observer.next(this.getState());
-            this.subscribe(state => observer.next(state));
-        });
+        this._value = Observable.from(store);
     }
 
     select<R>(keyOrSelector: ((state: any) => R) | string | number | symbol): Observable<R> {

--- a/src/app-store.ts
+++ b/src/app-store.ts
@@ -46,10 +46,10 @@ export class AppStore {
         this._value = Observable.from(store);
     }
 
-    select<R>(keyOrSelector: ((state: any) => R) | string | number | symbol): Observable<R> {
+    public select<R>(keyOrSelector: ((state: any) => R) | string | number | symbol): Observable<R> {
         if (typeof keyOrSelector === "string" || typeof keyOrSelector === "number"
                 || typeof keyOrSelector === "symbol") {
-            return this._value.map(state => state[<string|number|symbol>keyOrSelector]).distinctUntilChanged();
+            return this._value.map(state => state[<string|number|symbol> keyOrSelector]).distinctUntilChanged();
         } else if (typeof keyOrSelector === "function") {
             return this._value.map(keyOrSelector).distinctUntilChanged();
         } else {

--- a/test/actions.spec.ts
+++ b/test/actions.spec.ts
@@ -1,6 +1,7 @@
 import {it, describe, expect} from 'angular2/testing';
 import {Actions} from "../src/actions";
 import {AppStore} from "../src/app-store";
+import {createStore} from 'redux'
 
 class SomeActions extends Actions {
     someAction1(data) { return {type:"1",data} }
@@ -11,7 +12,7 @@ class SomeMoreActions extends Actions {
     someAction(data) { return {type:"a",data} }
 }
 const createAppStoreMock = () => {
-  const appStoreMock:AppStore = new AppStore({});
+  const appStoreMock:AppStore = new AppStore(createStore(state => state));
   spyOn(appStoreMock, "dispatch");
   return appStoreMock;
 }

--- a/test/app-store.spec.ts
+++ b/test/app-store.spec.ts
@@ -1,12 +1,13 @@
 import {it, describe, expect} from 'angular2/testing';
 import {AppStore} from "../src/app-store";
 import {createStore} from "redux";
+import {Observable} from 'rxjs/Observable';
 
 
 const createSimpleAppStore = () => {
-  return new AppStore(createStore((state=0,action) => {
-      if (action.type=="inc") {
-        return state+1;
+  return new AppStore(createStore((state: number = 0, action): number => {
+      if (action.type === "inc") {
+        return state + 1;
       } else {
         return state;
       }
@@ -15,7 +16,7 @@ const createSimpleAppStore = () => {
 
 export function main() {
 
-  describe('Actions', () => {
+  describe('Dispatching Actions', () => {
 
     it('subscription is called when dispatching actions', () => {
 
@@ -43,6 +44,93 @@ export function main() {
 
     });
 
+  });
+
+  describe('Observable', () => {
+
+      it('returned by select()', () => {
+          const appStore = createSimpleAppStore();
+          const state$ = appStore.select(state => state);
+          expect(state$).toImplement(Observable);
+      });
+
+      it('contains initial state', () => {
+          const appStore = createSimpleAppStore();
+          let currentState;
+
+          appStore.select(state => state)
+              .subscribe(state => currentState = state);
+
+          expect(currentState).toEqual(0);
+      });
+
+      it('updates on dispatch', () => {
+          const appStore = createSimpleAppStore();
+          let currentState;
+
+          appStore.select(state => state)
+              .subscribe(state => currentState = state);
+
+          appStore.dispatch({type:"inc"});
+
+          expect(currentState).toEqual(1);
+      })
+
+      it('maps with given selector function', () => {
+          const appStore = createSimpleAppStore();
+          const selector = jasmine.createSpy().and.callFake(state => state * state);
+          let currentState;
+
+          appStore.select(selector)
+              .subscribe(state => currentState = state);
+
+          appStore.dispatch({type:"inc"});
+          expect(currentState).toEqual(1);
+
+          appStore.dispatch({type:"inc"});
+          expect(currentState).toEqual(4);
+
+          expect(selector.calls.count()).toBe(3);
+      });
+
+      it('maps with given key string', () => {
+          interface NestedState {foo: number}
+          const appStore = new AppStore(createStore((state: NestedState = {foo: 0}, action) => {
+              if (action.type === "inc") {
+                return {foo: state.foo + 1};
+              } else {
+                return state;
+              }
+          }));
+          let currentState;
+
+          appStore.select('foo')
+              .subscribe(state => currentState = state);
+
+          appStore.dispatch({type:"inc"});
+          expect(currentState).toEqual(1);
+
+          appStore.dispatch({type:"inc"});
+          expect(currentState).toEqual(2);
+      });
+
+      it('did not emit when selector returns equal values', () => {
+          const appStore = createSimpleAppStore();
+          const sameInstance = {};
+          const selector = jasmine.createSpy().and.returnValue(sameInstance);
+          const listener = jasmine.createSpy().and.callFake(state => currentState = state);
+          let currentState;
+
+          appStore.select(selector)
+              .subscribe(listener);
+
+          appStore.dispatch({type:"inc"});
+          appStore.dispatch({type:"inc"});
+          expect(currentState).toEqual(sameInstance);
+
+          expect(selector.calls.count()).toBe(3);
+          expect(listener.calls.count()).toBe(1);
+      });
   });
 
 };


### PR DESCRIPTION
Currently I am missing the ability to work with observables on the store. This is a nice feature which is currently implemented in ngrx/store, but I like the idea to just wrap the actual redux library. So I implemented the `select()` function from ngrx/strore and this comes with this pull request.

The idea is simply call `select()` on the store an pass a key or a selector function which extracts the required informations from the store. The method returns an observable which only emit data if the value, returned by the selector, changes.

```javascript
export class AppComponent implements OnInit {

    constructor(private store: AppStore) {
    }

    ngOnInit() {
        // selects counter property from store
        this.counter$ = this.store.select('counter');

        // selects deep nested information from a immutable.js map
        this.foo$ = this.store.select(state => state.getIn(['foo', 'bar' 'counter']));
    }

    // ...
}
```

The ability to pass a selector function enables cool possibilities like passing memoized selector functions from [reselect](https://github.com/reactjs/reselect):

```javascript
import { createSelector } from 'reselect';

const getVisibilityFilter = (state) => state.visibilityFilter
const getTodos = (state) => state.todos

const getVisibleTodos = createSelector(
    [ getVisibilityFilter, getTodos ],
    (visibilityFilter, todos) => {
        switch (visibilityFilter) {
            case 'SHOW_ALL':
                return todos
            case 'SHOW_COMPLETED':
                return todos.filter(t => t.completed)
            case 'SHOW_ACTIVE':
                return todos.filter(t => !t.completed)
        }
    }
)

@Component({
    // ...
})
export class MyComponent implements OnInit {

    constructor(private store: AppStore) {
    }

    ngOnInit() {
        // selects counter property from store
        this.todos$ = this.store.select(getVisibleTodos);
    }

    // ...
}
```